### PR TITLE
Add `value` field to `ErrorKind::UnexpectedValue`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -44,7 +44,6 @@ rustflags = [
     "-Wclippy::match_wild_err_arm",
     "-Wclippy::match_wildcard_for_single_variants",
     "-Wclippy::mem_forget",
-    "-Wclippy::mismatched_target_os",
     "-Wclippy::missing_enforced_import_renames",
     "-Wclippy::mut_mut",
     "-Wclippy::mutex_integer",
@@ -76,7 +75,7 @@ rustflags = [
     "-Wnonstandard_style",
     "-Wrust_2018_idioms",
     # END - Embark standard lints v6 for Rust 1.55+
-    "-Dmissing_docs",
+    "-Dunexpected_cfgs",
 ]
 
 [target.'cfg(target_env = "musl")']

--- a/toml-span/src/de.rs
+++ b/toml-span/src/de.rs
@@ -61,7 +61,7 @@ struct Ctx<'de, 'b> {
     //array: bool,
 }
 
-impl<'de, 'b> Ctx<'de, 'b> {
+impl Ctx<'_, '_> {
     #[inline]
     fn error(&self, start: usize, end: Option<usize>, kind: ErrorKind) -> Error {
         self.de.error(start, end, kind)
@@ -1102,7 +1102,7 @@ enum E<'a> {
     DottedTable(Vec<TablePair<'a>>),
 }
 
-impl<'a> E<'a> {
+impl E<'_> {
     #[allow(dead_code)]
     fn type_name(&self) -> &'static str {
         match *self {

--- a/toml-span/src/error.rs
+++ b/toml-span/src/error.rs
@@ -129,6 +129,8 @@ pub enum ErrorKind {
     UnexpectedValue {
         /// The list of values that could have been used, eg. typically enum variants
         expected: &'static [&'static str],
+        /// The actual value that was found.
+        value: Option<String>,
     },
 }
 
@@ -225,7 +227,7 @@ impl Display for Error {
             ErrorKind::Deprecated { old, new } => {
                 write!(f, "field '{old}' is deprecated, '{new}' has replaced it")?;
             }
-            ErrorKind::UnexpectedValue { expected } => write!(f, "expected '{expected:?}'")?,
+            ErrorKind::UnexpectedValue { expected, .. } => write!(f, "expected '{expected:?}'")?,
         }
 
         // if !self.key.is_empty() {
@@ -328,7 +330,7 @@ impl Error {
                 .with_labels(vec![
                     Label::primary(fid, self.span).with_message("deprecated field")
                 ]),
-            ErrorKind::UnexpectedValue { expected } => diag
+            ErrorKind::UnexpectedValue { expected, .. } => diag
                 .with_message(format!("expected '{expected:?}'"))
                 .with_labels(vec![
                     Label::primary(fid, self.span).with_message("unexpected value")

--- a/toml-span/src/impl_serde.rs
+++ b/toml-span/src/impl_serde.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use serde::ser::{SerializeMap, SerializeSeq};
 
-impl<'de> serde::Serialize for Value<'de> {
+impl serde::Serialize for Value<'_> {
     fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/toml-span/src/lib.rs
+++ b/toml-span/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
+#![deny(missing_docs)]
 
 pub mod de;
 pub mod de_helpers;

--- a/toml-span/src/tokens.rs
+++ b/toml-span/src/tokens.rs
@@ -484,7 +484,7 @@ impl<'a> Tokenizer<'a> {
     }
 }
 
-impl<'a> Iterator for CrlfFold<'a> {
+impl Iterator for CrlfFold<'_> {
     type Item = (usize, char);
 
     fn next(&mut self) -> Option<(usize, char)> {
@@ -531,7 +531,7 @@ fn is_keylike(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || ch == '-' || ch == '_'
 }
 
-impl<'a> Token<'a> {
+impl Token<'_> {
     pub fn describe(&self) -> &'static str {
         match *self {
             Token::Keylike(_) => "an identifier",

--- a/toml-span/src/value.rs
+++ b/toml-span/src/value.rs
@@ -209,7 +209,7 @@ impl<'de> AsRef<ValueInner<'de>> for Value<'de> {
     }
 }
 
-impl<'de> fmt::Debug for Value<'de> {
+impl fmt::Debug for Value<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.value)
     }
@@ -225,43 +225,43 @@ pub struct Key<'de> {
     pub span: Span,
 }
 
-impl<'de> std::borrow::Borrow<str> for Key<'de> {
+impl std::borrow::Borrow<str> for Key<'_> {
     fn borrow(&self) -> &str {
         self.name.as_ref()
     }
 }
 
-impl<'de> fmt::Debug for Key<'de> {
+impl fmt::Debug for Key<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.name)
     }
 }
 
-impl<'de> fmt::Display for Key<'de> {
+impl fmt::Display for Key<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.name)
     }
 }
 
-impl<'de> Ord for Key<'de> {
+impl Ord for Key<'_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.name.cmp(&other.name)
     }
 }
 
-impl<'de> PartialOrd for Key<'de> {
+impl PartialOrd for Key<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<'de> PartialEq for Key<'de> {
+impl PartialEq for Key<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.name.eq(&other.name)
     }
 }
 
-impl<'de> Eq for Key<'de> {}
+impl Eq for Key<'_> {}
 
 /// A toml table, always represented as a sorted map.
 ///


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Besides showing which values are supported when parsing an enum I would also like to show the user a help message when the user specified value is "very close" to one of the possible values. To do that, I need to be able to access the value in the error handler.

E.g.

```
× Expected one of 'first-index', 'unsafe-first-match', 'unsafe-best-match'
   ╭─[file.toml:2:27]
 1 │ 
 2 │         index-strategy = "UnsafeFirstMatch"
   ·                           ────────────────
 3 │         
   ╰────
help: Did you mean 'unsafe-first-match'? 
```

### Related Issues

-
