### PR TITLE
Allow defining subtables of tables created via dotted keys

### DIFF
--- a/integ-tests/data/array_within_dotted.toml
+++ b/integ-tests/data/array_within_dotted.toml
@@ -1,0 +1,5 @@
+[fruit]
+apple.color = "red"
+
+[[fruit.apple.seeds]]
+size = 2

--- a/integ-tests/data/table_9_invalid.toml
+++ b/integ-tests/data/table_9_invalid.toml
@@ -1,0 +1,9 @@
+[fruit]
+apple.color = "red"
+apple.taste.sweet = true
+
+# [fruit.apple]  # INVALID
+[fruit.apple.taste]  # INVALID
+
+[fruit.apple.texture]  # you can add sub-tables
+smooth = true

--- a/integ-tests/data/table_9_reverse_invalid.toml
+++ b/integ-tests/data/table_9_reverse_invalid.toml
@@ -1,0 +1,9 @@
+# [fruit.apple]  # INVALID
+[fruit.apple.taste]  # INVALID
+
+[fruit]
+apple.color = "red"
+apple.taste.sweet = true
+
+[fruit.apple.texture]  # you can add sub-tables
+smooth = true

--- a/integ-tests/data/table_9_reverse_valid.toml
+++ b/integ-tests/data/table_9_reverse_valid.toml
@@ -1,0 +1,9 @@
+[fruit.apple.texture]  # you can add sub-tables
+smooth = true
+
+[fruit]
+apple.color = "red"
+apple.taste.sweet = true
+
+# [fruit.apple]  # INVALID
+# [fruit.apple.taste]  # INVALID

--- a/integ-tests/data/table_9_valid.toml
+++ b/integ-tests/data/table_9_valid.toml
@@ -1,0 +1,9 @@
+[fruit]
+apple.color = "red"
+apple.taste.sweet = true
+
+# [fruit.apple]  # INVALID
+# [fruit.apple.taste]  # INVALID
+
+[fruit.apple.texture]  # you can add sub-tables
+smooth = true

--- a/integ-tests/src/lib.rs
+++ b/integ-tests/src/lib.rs
@@ -221,8 +221,8 @@ macro_rules! invalid {
             let toml_str =
                 std::fs::read_to_string(dbg!(concat!("data/", stringify!($name), ".toml")))
                     .expect(concat!("failed to load ", stringify!($name), ".toml"));
-            let error = toml_span::parse(toml_str).unwrap_err();
-            $crate::error_snapshot!($name, error, &toml_str);
+            let error = toml_span::parse(&toml_str).unwrap_err();
+            $crate::error_snapshot!($name, Some(error.to_diagnostic(())), &toml_str);
         }
     };
     ($name:ident, $toml:expr) => {

--- a/integ-tests/tests/parser.rs
+++ b/integ-tests/tests/parser.rs
@@ -49,6 +49,12 @@ name = "Born in the USA"
 "#
 );
 
+valid!(table_9_valid);
+valid!(table_9_reverse_valid);
+invalid!(table_9_invalid);
+invalid!(table_9_reverse_invalid);
+valid!(array_within_dotted);
+
 mod stray_cr {
     use super::invalid;
 

--- a/integ-tests/tests/snapshots/parser__array_within_dotted-2.snap
+++ b/integ-tests/tests/snapshots/parser__array_within_dotted-2.snap
@@ -1,0 +1,54 @@
+---
+source: integ-tests/tests/parser.rs
+expression: spans
+---
+note[string]: root_fruit_apple_color
+  ┌─ array_within_dotted:2:16
+  │
+2 │ apple.color = "red"
+  │                ^^^
+
+note[integer]: root_fruit_apple_seeds_0_size
+  ┌─ array_within_dotted:5:8
+  │
+5 │ size = 2
+  │        ^
+
+note[table]: root_fruit_apple_seeds_0
+  ┌─ array_within_dotted:4:1
+  │  
+4 │ ╭ [[fruit.apple.seeds]]
+5 │ │ size = 2
+  │ ╰────────^
+
+note[array]: root_fruit_apple_seeds
+  ┌─ array_within_dotted:4:1
+  │  
+4 │ ╭ [[fruit.apple.seeds]]
+5 │ │ size = 2
+  │ ╰────────^
+
+note[table]: root_fruit_apple
+  ┌─ array_within_dotted:4:1
+  │  
+4 │ ╭ [[fruit.apple.seeds]]
+5 │ │ size = 2
+  │ ╰────────^
+
+note[table]: root_fruit
+  ┌─ array_within_dotted:1:1
+  │  
+1 │ ╭ [fruit]
+2 │ │ apple.color = "red"
+  │ ╰───────────────────^
+
+note[table]: root
+  ┌─ array_within_dotted:1:1
+  │  
+1 │ ╭ [fruit]
+2 │ │ apple.color = "red"
+3 │ │ 
+4 │ │ [[fruit.apple.seeds]]
+5 │ │ size = 2
+6 │ │ 
+  │ ╰^

--- a/integ-tests/tests/snapshots/parser__array_within_dotted.snap
+++ b/integ-tests/tests/snapshots/parser__array_within_dotted.snap
@@ -1,0 +1,16 @@
+---
+source: integ-tests/tests/parser.rs
+expression: valid_toml
+---
+{
+  "fruit": {
+    "apple": {
+      "color": "red",
+      "seeds": [
+        {
+          "size": 2
+        }
+      ]
+    }
+  }
+}

--- a/integ-tests/tests/snapshots/parser__table_9_invalid.snap
+++ b/integ-tests/tests/snapshots/parser__table_9_invalid.snap
@@ -1,0 +1,12 @@
+---
+source: integ-tests/tests/parser.rs
+expression: error
+---
+error[duplicate-key]: 
+  ┌─ table_9_invalid:6:14
+  │
+3 │ apple.taste.sweet = true
+  │       ----- first key instance
+  ·
+6 │ [fruit.apple.taste]  # INVALID
+  │              ^^^^^ duplicate key

--- a/integ-tests/tests/snapshots/parser__table_9_reverse_invalid.snap
+++ b/integ-tests/tests/snapshots/parser__table_9_reverse_invalid.snap
@@ -1,0 +1,12 @@
+---
+source: integ-tests/tests/parser.rs
+expression: error
+---
+error[duplicate-key]: 
+  ┌─ table_9_reverse_invalid:2:14
+  │
+2 │ [fruit.apple.taste]  # INVALID
+  │              ^^^^^ duplicate key
+  ·
+6 │ apple.taste.sweet = true
+  │       ----- first key instance

--- a/integ-tests/tests/snapshots/parser__table_9_reverse_valid-2.snap
+++ b/integ-tests/tests/snapshots/parser__table_9_reverse_valid-2.snap
@@ -1,0 +1,60 @@
+---
+source: integ-tests/tests/parser.rs
+expression: spans
+---
+note[string]: root_fruit_apple_color
+  ┌─ table_9_reverse_valid:5:16
+  │
+5 │ apple.color = "red"
+  │                ^^^
+
+note[bool]: root_fruit_apple_taste_sweet
+  ┌─ table_9_reverse_valid:6:21
+  │
+6 │ apple.taste.sweet = true
+  │                     ^^^^
+
+note[table]: root_fruit_apple_taste
+  ┌─ table_9_reverse_valid:6:21
+  │
+6 │ apple.taste.sweet = true
+  │                     ^^^^
+
+note[bool]: root_fruit_apple_texture_smooth
+  ┌─ table_9_reverse_valid:2:10
+  │
+2 │ smooth = true
+  │          ^^^^
+
+note[table]: root_fruit_apple_texture
+  ┌─ table_9_reverse_valid:1:1
+  │  
+1 │ ╭ [fruit.apple.texture]  # you can add sub-tables
+2 │ │ smooth = true
+  │ ╰─────────────^
+
+note[table]: root_fruit_apple
+  ┌─ table_9_reverse_valid:1:1
+  │  
+1 │ ╭ [fruit.apple.texture]  # you can add sub-tables
+2 │ │ smooth = true
+  │ ╰─────────────^
+
+note[table]: root_fruit
+  ┌─ table_9_reverse_valid:1:1
+  │  
+1 │ ╭ [fruit.apple.texture]  # you can add sub-tables
+2 │ │ smooth = true
+  │ ╰─────────────^
+
+note[table]: root
+   ┌─ table_9_reverse_valid:1:1
+   │  
+ 1 │ ╭ [fruit.apple.texture]  # you can add sub-tables
+ 2 │ │ smooth = true
+ 3 │ │ 
+ 4 │ │ [fruit]
+   · │
+ 9 │ │ # [fruit.apple.taste]  # INVALID
+10 │ │ 
+   │ ╰^

--- a/integ-tests/tests/snapshots/parser__table_9_reverse_valid.snap
+++ b/integ-tests/tests/snapshots/parser__table_9_reverse_valid.snap
@@ -1,0 +1,17 @@
+---
+source: integ-tests/tests/parser.rs
+expression: valid_toml
+---
+{
+  "fruit": {
+    "apple": {
+      "color": "red",
+      "taste": {
+        "sweet": true
+      },
+      "texture": {
+        "smooth": true
+      }
+    }
+  }
+}

--- a/integ-tests/tests/snapshots/parser__table_9_valid-2.snap
+++ b/integ-tests/tests/snapshots/parser__table_9_valid-2.snap
@@ -1,0 +1,61 @@
+---
+source: integ-tests/tests/parser.rs
+expression: spans
+---
+note[string]: root_fruit_apple_color
+  ┌─ table_9_valid:2:16
+  │
+2 │ apple.color = "red"
+  │                ^^^
+
+note[bool]: root_fruit_apple_taste_sweet
+  ┌─ table_9_valid:3:21
+  │
+3 │ apple.taste.sweet = true
+  │                     ^^^^
+
+note[table]: root_fruit_apple_taste
+  ┌─ table_9_valid:3:21
+  │
+3 │ apple.taste.sweet = true
+  │                     ^^^^
+
+note[bool]: root_fruit_apple_texture_smooth
+  ┌─ table_9_valid:9:10
+  │
+9 │ smooth = true
+  │          ^^^^
+
+note[table]: root_fruit_apple_texture
+  ┌─ table_9_valid:8:1
+  │  
+8 │ ╭ [fruit.apple.texture]  # you can add sub-tables
+9 │ │ smooth = true
+  │ ╰─────────────^
+
+note[table]: root_fruit_apple
+  ┌─ table_9_valid:8:1
+  │  
+8 │ ╭ [fruit.apple.texture]  # you can add sub-tables
+9 │ │ smooth = true
+  │ ╰─────────────^
+
+note[table]: root_fruit
+  ┌─ table_9_valid:1:1
+  │  
+1 │ ╭ [fruit]
+2 │ │ apple.color = "red"
+3 │ │ apple.taste.sweet = true
+  │ ╰────────────────────────^
+
+note[table]: root
+   ┌─ table_9_valid:1:1
+   │  
+ 1 │ ╭ [fruit]
+ 2 │ │ apple.color = "red"
+ 3 │ │ apple.taste.sweet = true
+ 4 │ │ 
+   · │
+ 9 │ │ smooth = true
+10 │ │ 
+   │ ╰^

--- a/integ-tests/tests/snapshots/parser__table_9_valid.snap
+++ b/integ-tests/tests/snapshots/parser__table_9_valid.snap
@@ -1,0 +1,17 @@
+---
+source: integ-tests/tests/parser.rs
+expression: valid_toml
+---
+{
+  "fruit": {
+    "apple": {
+      "color": "red",
+      "taste": {
+        "sweet": true
+      },
+      "texture": {
+        "smooth": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This PR rewrites `deserialize_table` to fix https://github.com/EmbarkStudios/toml-span/issues/8. This is achieved by passing tables created via dotted keys to the corresponding subtable. 